### PR TITLE
Add config-driven asset paths

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,3 @@
+const config = {
+  imageBasePath: 'images' // default path for images
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Peptidesource</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="config.js"></script>
+</head>
+<body>
+    <header class="hero">
+        <h1>Welcome to Peptidesource</h1>
+        <img id="hero-image" alt="Hero">
+    </header>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // set hero image src
+        var heroImg = document.getElementById('hero-image');
+        heroImg.src = config.imageBasePath + '/hero.jpg';
+
+        // update css variable for background image example
+        var root = document.documentElement;
+        root.style.setProperty('--hero-bg', 'url(' + config.imageBasePath + '/hero-bg.jpg)');
+    });
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,22 @@
+:root {
+  --hero-bg: url('images/hero-bg.jpg');
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.hero {
+  background-image: var(--hero-bg);
+  background-size: cover;
+  text-align: center;
+  padding: 50px;
+  color: #fff;
+}
+
+#hero-image {
+  width: 200px;
+  height: auto;
+}


### PR DESCRIPTION
## Summary
- add a tiny site with `index.html` and `style.css`
- use a `config.js` for storing image path
- reference the config from HTML and CSS variables

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68435b62cc008320a0c35892e32597bf