### PR TITLE
Update OpenAI client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ Simple FastAPI server that forwards chat prompts to the OpenAI API.
 
 ```
 source venv/bin/activate
+pip install -r requirements.txt
 uvicorn server:app --reload
 ```
 
 Set `OPENAI_API_KEY` in your environment before starting the server.
+
+Example chat request:
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Hello"}'
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
 uvicorn
-openai
+openai>=1

--- a/server.py
+++ b/server.py
@@ -10,22 +10,22 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+api_key = os.getenv("OPENAI_API_KEY")
+client = openai.AsyncOpenAI(api_key=api_key)
 
 class ChatRequest(BaseModel):
     prompt: str
 
 
 def sanitize(message: str) -> str:
-    key = openai.api_key
-    if key:
-        message = message.replace(key, "[REDACTED]")
+    if api_key:
+        message = message.replace(api_key, "[REDACTED]")
     return message
 
 @app.post("/chat")
 async def chat(req: ChatRequest):
     try:
-        resp = await openai.ChatCompletion.acreate(
+        resp = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": req.prompt}],
         )


### PR DESCRIPTION
## Summary
- use `AsyncOpenAI` client
- document dependencies and example request in README
- require OpenAI 1.x

## Testing
- `python -m py_compile server.py`
- `uvicorn server:app --port 8000 --host 0.0.0.0` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68435fce59d0832097dc7ed58881c173